### PR TITLE
Update numpy_records.py

### DIFF
--- a/arctic/serialization/numpy_records.py
+++ b/arctic/serialization/numpy_records.py
@@ -2,11 +2,15 @@ import logging
 import numpy as np
 
 from pandas import DataFrame, MultiIndex, Series, DatetimeIndex, Index
-try:
+try:  # 0.21+ Compatibility
     from pandas._libs.tslib import Timestamp
     from pandas._libs.tslibs.timezones import get_timezone
 except ImportError:
-    from pandas.tslib import Timestamp, get_timezone
+    try:  # 0.20.x Compatibility
+        from pandas._libs.tslib import Timestamp, get_timezone
+    except ImportError:  # <= 0.19 Compatibility
+        from pandas.tslib import Timestamp, get_timezone
+
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
Re-adding compatibility for pandas 0.20.x #468.
The get_timezone library was moved around in 0.20 and 0.21. We are still using it even though it was deprecated, so adding some missing version compatibilities.